### PR TITLE
Fixes raytheonbbn/hammer#2

### DIFF
--- a/app/src/main/java/audiomodem/Sender.java
+++ b/app/src/main/java/audiomodem/Sender.java
@@ -1,10 +1,15 @@
 package audiomodem;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioTrack;
 import android.os.AsyncTask;
+import android.util.Base64;
 import android.util.Log;
+
+import com.atakmap.android.cot_utility.plugin.PluginLifecycle;
 
 import utils.ModemCotUtility;
 
@@ -88,6 +93,33 @@ public class Sender extends AsyncTask<String, Double, Void> {
         int n = dst.write(samples, 0, samples.length);
         double duration = ((double) n) / sampleRate;
         Log.d(TAG, String.format("playing %d samples (%f seconds)", n, duration));
+
+        if(modemCotUtility.useSlowVox) {
+            Log.i(TAG, String.format("slowVox: Enabled"));
+            SharedPreferences sharedPref = PluginLifecycle.activity.getSharedPreferences("hammer-prefs", Context.MODE_PRIVATE);
+            byte[] beep_bytes = Base64.decode(sharedPref.getString("b64_beep_bytes", ""), Base64.DEFAULT);
+            Log.d(TAG, String.format("beep_bytes.length = %d", beep_bytes.length));
+            AudioTrack beep = new AudioTrack(
+                    streamType,
+                    sampleRate,
+                    chanFormat,
+                    encoding,
+                    beep_bytes.length,
+                    mode
+            );
+            if (beep_bytes.length != beep.write(beep_bytes, 0, beep_bytes.length)) {
+                Log.w(TAG, "beep lengths don't match");
+            }
+            beep.play();
+            try {
+                Thread.sleep(1000);
+            } catch(InterruptedException e) {
+                Log.e(TAG, String.format("slowVox: sleep failed"));
+            } finally {
+                beep.stop();
+                beep.release();
+            }
+        }
 
         dst.play();
         try {

--- a/app/src/main/java/com/atakmap/android/cot_utility/receivers/SettingsReceiver.java
+++ b/app/src/main/java/com/atakmap/android/cot_utility/receivers/SettingsReceiver.java
@@ -3,12 +3,16 @@ package com.atakmap.android.cot_utility.receivers;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.util.Base64;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.Switch;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 import com.atakmap.android.cot_utility.plugin.PluginLifecycle;
 import com.atakmap.android.cot_utility.plugin.R;
@@ -30,6 +34,7 @@ public class SettingsReceiver extends DropDownReceiver {
 
     private Switch enableReceiveButton;
     private Switch abbreviateCotSwitch;
+    private Switch slowVoxSwitch;
     private ModemCotUtility modemCotUtility;
     private Context context;
 
@@ -46,6 +51,7 @@ public class SettingsReceiver extends DropDownReceiver {
 
         enableReceiveButton = settingsView.findViewById(R.id.enableReceiveCoTFromModem);
         abbreviateCotSwitch = settingsView.findViewById(R.id.abbreviateCot);
+        slowVoxSwitch       = settingsView.findViewById(R.id.slowVox);
 
         ImageButton backButton = settingsView.findViewById(R.id.backButtonSettingsView);
         backButton.setOnClickListener(new View.OnClickListener() {
@@ -122,6 +128,51 @@ public class SettingsReceiver extends DropDownReceiver {
                 enableReceiveButton.setChecked(false);
             }
 
+            slowVoxSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+                    ModemCotUtility.useSlowVox = b;
+
+                    SharedPreferences sharedPref = PluginLifecycle.activity.getSharedPreferences("hammer-prefs", Context.MODE_PRIVATE);
+                    SharedPreferences.Editor editor = sharedPref.edit();
+                    editor.putBoolean("useSlowVox", b);
+                    editor.apply();
+
+                    if (sharedPref.getString("b64_beep_bytes", "").isEmpty()) {
+                        Log.i(TAG, "slowVox: loading beep.wav");
+                        // TODO: figure out how to get the plugin's context
+                        //try {
+                        //   byte[] beep = new byte[4096];
+                        //   InputStream stream = PluginLifecycle.activity.getAssets().open("beep.wav");
+                        //   final int n = stream.read(beep);
+                        //   Log.i(TAG, String.format("beep.wav length: %d", n));
+                        //   if (n != 3424) { // on disk byte length of assets/beep.wav
+                        //       Log.w(TAG, String.format("slowVox: reading assets/beep.wav mismatch length"));
+                        //   }
+                        //   stream.close();
+                        //   editor.putString("b64_beep_bytes", Base64.encodeToString(beep, Base64.DEFAULT));
+                        //} catch(IOException e) {
+                        //    Log.e(TAG, "failed to open beep.wav: " + e);
+                        //}
+
+                        // HACK: I couldn't get the plugin's context to access beep.wav from assets/ so here is beep.wav in a base64 encoded string
+                        editor.putString("b64_beep_bytes", "UklGRlgNAABXQVZFZm10IBAAAAABAAEAIlYAAESsAAACABAAZGF0YTQNAABAAX8QRSE2L0w5Dz/RPww79DEMJZ4UzwMf9MLiEdT/yPXB3L9EwzvLT9fu5rX3TAgSGbIoxTS9PCVACz4CN+8rPx3hCzL8Yuv02g3O9MQywO7AusbB0MzeU+8AAK0QNCFAL0Y5Ej/OPww79DEMJZ4UzwMf9MLiEdT/yPXB3L9EwzvLT9fu5rX3TAgSGbIoxTS9PCVACz4CN+8rPx3hCzL8Yuv02g3O9MQywO7AusbB0MzeU+8AAK0QNCFAL0Y5Ej/OPww79DEMJZ4UzwMf9MLiEdT/yPXB3L9EwzvLT9fu5rX3TAgSGbIoxTS9PCVACz4CN+8rPx3hCzL8Yuv02g3O9MQywO7AusbB0MzeU+8AAK0QNCFAL0Y5Ej/OPww79DEMJZ4UzwMf9MLiEdT/yPXB3L9EwzvLT9fu5rX3TAgSGbIoxTS9PCVACz4CN+8rPx3hCzL8Yuv02g3O9MQywO7AusbB0MzeU+8AAK0QNCFAL0Y5Ej/OPww79DEMJZ4UzwMf9MLiEdT/yPXB3L9EwzvLT9fu5rX3TAgSGbIoxTS9PCVACz4CN+8rPx3hCzL8Yuv02g3O9MQywO7AusbB0MzeU+8AAK0QNCFAL0Y5Ej/OPww79DEMJZ4UzwMf9MLiEdT/yPXB3L9EwzvLT9fu5rX3TAgSGbIoxTS9PCVACz4CN+8rPx3hCzL8Yuv02g3O9MQywO7AusbB0MzeU+8AAK0QNCFAL0Y5Ej/OPww79DEMJZ4UzwMf9MLiEdT/yPXB3L9EwzvLT9fu5rX3TAgSGbIoxTS9PCVACz4CN+8rPx3hCzL8Yuv02g3O9MQywO7AusbB0MzeU+8AAK0QNCFAL0Y5Ej/OPww79DEMJZ4UzwMf9MLiEdT/yPXB3L9EwzvLT9fu5rX3TAgSGbIoxTS9PCVACz4CN+8rPx3hCzL8Yuv02g3O9MQywO7AusbB0MzeU+8AAK0QNCFAL0Y5Ej/OPww79DEMJZ4UzwMf9MLiEdT/yPXB3L9EwzvLT9fu5rX3TAgSGbIoxTS9PCVACz4CN+8rPx3hCzL8Yuv02g3O9MQywO7AusbB0MzeU+8AAK0QNCFAL0Y5Ej/OPww79DEMJZ4UzwMf9MLiEdT/yPXB3L9EwzvLT9fu5rX3TAgSGbIoxTS9PCVACz4CN+8rPx3hCzL8Yev22gnO/MQgwDLBRMfG0bbfJvHJAKURACKpL885ET/JPxw7NDH8I6YTygIk873hGdPxx6/B+b+iwxLMOdhQ6Dr53gg8GhgpXTX9PA1AJD69NuEqRhzcCjb7XOr+2fjMPMQxwCrBSMfE0bffJvHJAKURACKpL885ET/JPxw7NDH8I6YTygIk873hGdPxx6/B+b+iwxLMOdhQ6Dr53gg8GhgpXTX9PA1AJD69NuEqRhzcCjb7XOr+2fjMPMQxwCrBSMfE0bffJvHJAKURACKpL885ET/JPxw7NDH8I6YTygIk873hGdPxx6/B+b+iwxLMOdhQ6Dr53gg8GhgpXTX9PA1AJD69NuEqRhzcCjb7XOr+2fjMPMQxwCrBSMfE0bffJvHJAKURACKpL885ET/JPxw7NDH8I6YTygIk873hGdPxx6/B+b+iwxLMOdhQ6Dr53gg8GhgpXTX9PA1AJD69NuEqRhzcCjb7XOr+2fjMPMQxwCrBSMfE0bffJvHJAKURACKpL885ET/JPxw7NDH8I6YTygIk873hGdPxx6/B+b+iwxLMOdhQ6Dr53gg8GhgpXTX9PA1AJD69NuEqRhzcCjb7XOr+2fjMPMQxwCrBSMfE0bffJvHJAKURACKpL885ET/JPxw7NDH8I6YTygIk873hGdPxx6/B+b+iwxLMOdhQ6Dr53gg8GhgpXTX9PA1AJD69NuEqRhzcCjb7XOr+2fjMPMQxwCrBSMfE0bffJvHJAKURACKpL885ET/JPxw7NDH8I6YTygIk873hGdPxx6/B+b+iwxLMOdhQ6Dr53gg8GhgpXTX9PA1AJD69NuEqRhzcCjb7XOr+2fjMPMQxwCrBSMfE0bffJvHJAKURACKpL885ET/JPxw7NDH8I6YTygIk873hGdPxx6/B+b+iwxLMOdhQ6Dr53gg8GhgpXTX9PA1AJD69NuEqRhzcCjb7XOr+2fjMPMQxwCrBSMfE0bffJvHJAKURACKpL885ET/JPxw7NDH8I6YTygIk873hGdPxx6/B+b+iwxLMOdhQ6Dr53gg8GhgpXTX9PA1AJD69NuEqRhzcCjb7XOr+2fjMPMQxwCrBSMfE0bffJvHJAKURACKpL885ET/JPxw7NDH8I6YTygIk873hGdPxx6/B+b+iwxLMOdhQ6Dr53gg8GhgpXTX+PAtAKD61NvIqBRzPCTf6Z+nj2NLM+MPgvzbB+sdc0qvgLPLEAasS9iK+MAc6ET8RPwc6vjD2IqsSxAEs8qvgXNL6xzbB4L/4w9PM39hu6Sn66wkvGywqGDb2POI/9jwYNiwqLxvrCSn6bunf2NPM+MPgvzbB+sdc0qvgLPLEAasS9iK+MAc6ET8RPwc6vjD2IqsSxAEs8qvgXNL6xzbB4L/4w9PM39hu6Sn66wkvGywqGDb2POI/9jwYNiwqLxvrCSn6bunf2NPM+MPgvzbB+sdc0qvgLPLEAasS9iK+MAc6ET8RPwc6vjD2IqsSxAEs8qvgXNL6xzbB4L/4w9PM39hu6Sn66wkvGywqGDb2POI/9jwYNiwqLxvrCSn6bunf2NPM+MPgvzbB+sdc0qvgLPLEAasS9iK+MAc6ET8RPwc6vjD2IqsSxAEs8qvgXNL6xzbB4L/4w9PM39hu6Sn66wkvGywqGDb2POI/9jwYNiwqLxvrCSn6bunf2NPM+MPgvzbB+sdc0qvgLPLEAasS9iK+MAc6ET8RPwc6vjD2IqsSxAEs8qvgXNL6xzbB4L/4w9PM39hu6Sn66wkvGywqGDb2POI/9jwYNiwqLxvrCSn6bunf2NPM+MPgvzbB+sdc0qvgLPLEAasS9iK+MAc6ET8RPwc6vjD2IqsSxAEs8qvgXNL6xzbB4L/4w9PM39hu6Sn66wkvGywqGDb2POI/9jwYNiwqLxvrCSn6bunf2NPM+MPgvzbB+sdc0qvgLPLEAasS9iK+MAc6ET8RPwc6vjD2IqsSxAEs8qvgXNL6xzbB4L/4w9PM39hu6Sn66wkvGywqGDb2POI/9jwYNiwqLxvrCSn6bunf2NPM+MPgvzbB+sdc0qvgLPLEAasS9iK+MAc6ET8RPwc6vjD2IqsSxAEs8qvgXNL6xzbB4L/4w9PM39hu6Sn66wkvGywqGDb2POI/9jwYNiwqLxvrCSn6bunf2NPM+MPgvzbB+sdc0qvgLPLEAasS9iK+MAc6ET8RPwc6vjD2IqsSxAEs8qvgXNL6xzbB4L/4w9PM39hu6Sn66wkvGywqGDb2POI/9jwYNiwqLxvrCSn6bunf2NPM+MPgvzbB+sdc0qvgLPLEAasS9iK+MAc6ET8RPwc6vjD2IqsSxAEs8qvgXNL6xzbB4L/4w9PM4Nht6Sv66Ak0GyEqzjYcPhJA+jxeNRcpPBreCDr5UOg52BLMosP5v6/B8ccZ073hJPPKAqYT/CM0MRw7yT8RP885qS8AIqURyQAm8bffxNFIxyrBMcA8xPjM/tlc6jb73ApGHOEqvTYkPg1A/TxdNRgpPBreCDr5UOg52BLMosP5v6/B8ccZ073hJPPKAqYT/CM0MRw7yT8RP885qS8AIqURyQAm8bffxNFIxyrBMcA8xPjM/tlc6jb73ApGHOEqvTYkPg1A/TxdNRgpPBreCDr5UOg52BLMosP5v6/B8ccZ073hJPPKAqYT/CM0MRw7yT8RP885qS8AIqURyQAm8bffxNFIxyrBMcA8xPjM/tlc6jb73ApGHOEqvTYkPg1A/TxdNRgpPBreCDr5UOg52BLMosP5v6/B8ccZ073hJPPKAqYT/CM0MRw7yT8RP885qS8AIqURyQAm8bffxNFIxyrBMcA8xPjM/tlc6jb73ApGHOEqvTYkPg1A/TxdNRgpPBreCDr5UOg52BLMosP5v6/B8ccZ073hJPPKAqYT/CM0MRw7yT8RP885qS8AIqURyQAm8bffxNFIxyrBMcA8xPjM/tlc6jb73ApGHOEqvTYkPg1A/TxdNRgpPBreCDr5UOg52BLMosP5v6/B8ccZ073hJPPKAqYT/CM0MRw7yT8RP885qS8AIqURyQAm8bffxNFIxyrBMcA8xPjM/tlc6jb73ApGHOEqvTYkPg1A/TxdNRgpPBreCDr5UOg52BLMosP5v6/B8ccZ073hJPPKAqYT/CM0MRw7yT8RP885qS8AIqURyQAm8bffxNFIxyrBMcA8xPjM/tlc6jb73ApGHOEqvTYkPg1A/TxdNRgpPBreCDr5UOg52BLMosP5v6/B8ccX07/hH/PTAvYSriKILhk3fTrOOL0yUikEHYwOvQB69I/m8txC1fHRbNLt1SXd7+bf8cD9VAWwEg==");
+                        editor.apply();
+                    }
+                }
+             });
+
+             if(ModemCotUtility.useSlowVox){
+                 slowVoxSwitch.setChecked(true);
+             }else{
+                 slowVoxSwitch.setChecked(false);
+                 SharedPreferences sharedPref = PluginLifecycle.activity.getSharedPreferences("hammer-prefs", Context.MODE_PRIVATE);
+                 SharedPreferences.Editor editor = sharedPref.edit();
+                 editor = sharedPref.edit();
+                 editor.remove("b64_beep_bytes");
+                 editor.apply();
+                 Log.i(TAG, "slowVox: unloading beep.wav");
+             }
         }
     }
 

--- a/app/src/main/java/utils/ModemCotUtility.java
+++ b/app/src/main/java/utils/ModemCotUtility.java
@@ -46,6 +46,8 @@ public class ModemCotUtility extends DropDownReceiver implements DropDown.OnStat
     private final String padding = "000000000000000000000000000000000000000000000000000000000000000";
     public static boolean useAbbreviatedCoT = true;
 
+    public static boolean useSlowVox = false;
+
     private Set<ChatMessageListener> chatMessageListenerSet = new HashSet<>();
 
     public interface ChatMessageListener{

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -48,4 +48,13 @@
         android:layout_height="50dp"
         android:checked="true"/>
 
+   <Switch
+        android:layout_marginLeft="10dp"
+        android:layout_marginRight="10dp"
+        android:text="Slow VOX"
+        android:id="@+id/slowVox"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:checked="false"/>
+
 </LinearLayout>


### PR DESCRIPTION
This commit features a new setting called "Slow Vox". 

The purpose of this setting is to play a wav file prior to a message. Doing so ensures a radio with a slow VOX activation will be ready to transmit.

Tested with two Baofeng UV-5Rs with the following settings:
- Volume knob set to maxium
- SQL = 3
- VOX = 1

Tested with two Samsung Galaxy S9 with the following:
- ATAKCiv 4.2.0
- Media Volume set to maxium