### PR TITLE
Read Receipt for chat messages

### DIFF
--- a/app/src/main/java/audiomodem/Receiver.java
+++ b/app/src/main/java/audiomodem/Receiver.java
@@ -106,6 +106,7 @@ public class Receiver extends AsyncTask<Void, Double, Result> {
     @Override
     protected Result doInBackground(Void... params) {
 
+        int crc32 = 0;
         int chanFormat = AudioFormat.CHANNEL_IN_MONO;
         int encoding = AudioFormat.ENCODING_PCM_16BIT;
         int bufSize = AudioRecord.getMinBufferSize(sampleRate, chanFormat, encoding);
@@ -135,14 +136,14 @@ public class Receiver extends AsyncTask<Void, Double, Result> {
 
         src.startRecording();
         try {
-            Main.receive(input, output);
+            crc32 = Main.receive(input, output);
         } catch (Exception e) {
             if(e != null && e.getMessage() != null && e.getMessage().equalsIgnoreCase("stopped")) {
                 Log.e(TAG, "receiver stopped");
             } else {
                 Log.e(TAG, "receiver failed", e);
             }
-            return new Result(null, e.getMessage());
+            return new Result(null, e.getMessage(), crc32);
         } finally {
             if(src != null) {
                 src.stop();
@@ -162,7 +163,7 @@ public class Receiver extends AsyncTask<Void, Double, Result> {
                 os.close();
             } catch (IOException e) {
                 Log.e(TAG, "audio save failed", e);
-                return new Result(null, e.getMessage());
+                return new Result(null, e.getMessage(), crc32);
             }
         }
 
@@ -170,10 +171,10 @@ public class Receiver extends AsyncTask<Void, Double, Result> {
 
         try {
             String str = new String(output.toByteArray(), "UTF-8");
-            return new Result(str, null);
+            return new Result(str, null, crc32);
         } catch (UnsupportedEncodingException e) {
             Log.e(TAG, "unicode decoding failed", e);
-            return new Result(null, e.getMessage());
+            return new Result(null, e.getMessage(), crc32);
         }
     }
 }

--- a/app/src/main/java/audiomodem/Result.java
+++ b/app/src/main/java/audiomodem/Result.java
@@ -3,9 +3,11 @@ package audiomodem;
 public class Result {
     public final String out;
     public final String err;
+    public final int crc32;
 
-    public Result(String o, String e) {
+    public Result(String o, String e, int c) {
         out = o;
         err = e;
+        crc32 = c;
     }
 }

--- a/app/src/main/java/audiomodem/Sender.java
+++ b/app/src/main/java/audiomodem/Sender.java
@@ -104,7 +104,6 @@ public class Sender extends AsyncTask<String, Double, Void> {
         dst.stop();
         dst.release();
 
-        modemCotUtility.startListener();
         return null;
 
     }

--- a/app/src/main/java/audiomodem/jmodem/Demodulator.java
+++ b/app/src/main/java/audiomodem/jmodem/Demodulator.java
@@ -62,7 +62,7 @@ class Demodulator {
 		return result;
 	}
 
-	public void run(OutputStream dst) throws IOException {
+	public int run(OutputStream dst) throws IOException {
 		while (true) {
 			int len = getByte();
 			log.info("new packet: " + len + " bytes");
@@ -83,9 +83,11 @@ class Demodulator {
 				throw new IOException("bad checksum");
 			}
 			if (len == 0) {
-				return; // EOF
+				return got; // return the CRC32 of the msg
 			}
 			dst.write(buf, Config.checksumSize, len);
+
+			return got; // return the CRC32 of the msg
 		}
 	}
 }

--- a/app/src/main/java/audiomodem/jmodem/Main.java
+++ b/app/src/main/java/audiomodem/jmodem/Main.java
@@ -7,8 +7,8 @@ import java.util.logging.Logger;
 
 public class Main {
 
-	public static void receive(InputSampleStream src, OutputStream dst) throws IOException {
-		Receiver.run(src,  dst);
+	public static int receive(InputSampleStream src, OutputStream dst) throws IOException {
+		return Receiver.run(src,  dst);
 	}
 
 	public static void send(InputStream src, OutputSampleStream dst) throws IOException {

--- a/app/src/main/java/audiomodem/jmodem/Receiver.java
+++ b/app/src/main/java/audiomodem/jmodem/Receiver.java
@@ -13,7 +13,7 @@ class Receiver {
 	
 	private static final Logger log = Logger.getLogger("Receiver");
 
-	public static void run(InputSampleStream src, OutputStream dst) throws IOException {
+	public static int run(InputSampleStream src, OutputStream dst) throws IOException {
 		log.info("detecting");
 		Detector d = new Detector(src);
 		d.run();
@@ -27,9 +27,9 @@ class Receiver {
 
 		log.info("demodulating");
 		Demodulator r = new Demodulator(src, filt);
-		r.run(dst);
+		return r.run(dst);
 
-		log.info("done");
+		//log.info("done");
 	}
 
 	static class InputStreamWrapper implements InputSampleStream {

--- a/app/src/main/java/com/atakmap/android/cot_utility/receivers/SettingsReceiver.java
+++ b/app/src/main/java/com/atakmap/android/cot_utility/receivers/SettingsReceiver.java
@@ -30,6 +30,7 @@ public class SettingsReceiver extends DropDownReceiver {
 
     private Switch enableReceiveButton;
     private Switch abbreviateCotSwitch;
+    private Switch readReceiptSwitch;
     private ModemCotUtility modemCotUtility;
     private Context context;
 
@@ -46,6 +47,7 @@ public class SettingsReceiver extends DropDownReceiver {
 
         enableReceiveButton = settingsView.findViewById(R.id.enableReceiveCoTFromModem);
         abbreviateCotSwitch = settingsView.findViewById(R.id.abbreviateCot);
+        readReceiptSwitch   = settingsView.findViewById(R.id.readReceipt);
 
         ImageButton backButton = settingsView.findViewById(R.id.backButtonSettingsView);
         backButton.setOnClickListener(new View.OnClickListener() {
@@ -81,6 +83,24 @@ public class SettingsReceiver extends DropDownReceiver {
                     FULL_HEIGHT, false);
 
             modemCotUtility = ModemCotUtility.getInstance(mapView, context);
+
+            readReceiptSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+                    ModemCotUtility.useReadReceipt = b;
+
+                    SharedPreferences sharedPref = PluginLifecycle.activity.getSharedPreferences("hammer-prefs", Context.MODE_PRIVATE);
+                    SharedPreferences.Editor editor = sharedPref.edit();
+                    editor.putBoolean("useReadReceipt", b);
+                    editor.apply();
+                }
+            });
+
+            if(ModemCotUtility.useReadReceipt){
+                readReceiptSwitch.setChecked(true);
+            }else{
+                readReceiptSwitch.setChecked(false);
+            }
 
             abbreviateCotSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                 @Override

--- a/app/src/main/java/com/atakmap/android/cot_utility/receivers/ViewCoTMarkersReceiver.java
+++ b/app/src/main/java/com/atakmap/android/cot_utility/receivers/ViewCoTMarkersReceiver.java
@@ -89,6 +89,7 @@ public class ViewCoTMarkersReceiver extends ViewTableReceiver implements
                     android.util.Log.d(TAG, "sending self position");
                     ModemCotUtility.getInstance(mapView, pluginContext).stopListener();
                     ModemCotUtility.getInstance(mapView, pluginContext).sendCoT(mapView.getSelfMarker());
+                    ModemCotUtility.getInstance(mapView, pluginContext).startListener();
                     Toast toast = Toast.makeText(context, "sending self marker", Toast.LENGTH_SHORT);
                     toast.show();
                 }
@@ -134,6 +135,7 @@ public class ViewCoTMarkersReceiver extends ViewTableReceiver implements
                 public void onClick(View view) {
                     ModemCotUtility.getInstance(mapView, pluginContext).stopListener();
                     ModemCotUtility.getInstance(mapView, pluginContext).sendCoT(mapItem);
+                    ModemCotUtility.getInstance(mapView, pluginContext).startListener();
                 }
             });
 

--- a/app/src/main/java/utils/ModemCotUtility.java
+++ b/app/src/main/java/utils/ModemCotUtility.java
@@ -21,10 +21,12 @@ import com.atakmap.coremap.cot.event.CotEvent;
 import com.atakmap.coremap.log.Log;
 import com.atakmap.coremap.maps.coords.GeoPoint;
 
+import java.nio.ByteBuffer;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.zip.CRC32;
 
 import audiomodem.Receiver;
 import audiomodem.Result;
@@ -46,10 +48,14 @@ public class ModemCotUtility extends DropDownReceiver implements DropDown.OnStat
     private final String padding = "000000000000000000000000000000000000000000000000000000000000000";
     public static boolean useAbbreviatedCoT = true;
 
+    public static int MessageCRC = 0;
+    public static boolean useReadReceipt = false;
+
     private Set<ChatMessageListener> chatMessageListenerSet = new HashSet<>();
 
     public interface ChatMessageListener{
-        public void chatReceived(String message, String callsign, String timeMillis, String callsignDestination);
+        public void chatReceived(String message, String callsign, String timeMillis, String callsignDestination, int crc32);
+        public void markRead(String callsign, String crc32);
     }
 
     /**
@@ -157,7 +163,7 @@ public class ModemCotUtility extends DropDownReceiver implements DropDown.OnStat
                 receiveCot.set(true);
 
                 if(res.out != null)
-                    parseCoT(res.out);
+                    parseCoT(res.out, res.crc32);
 
                 if (res.err != null) {
                     Toast.makeText(MapView.getMapView().getContext(), "Error: " + res.err,
@@ -198,7 +204,7 @@ public class ModemCotUtility extends DropDownReceiver implements DropDown.OnStat
      * Parse message and extract CoT marker
      * @param message
      */
-    private void parseCoT(String message){
+    private void parseCoT(String message, int crc32){
         boolean foundStart = false;
         StringBuilder stringBuilder = new StringBuilder();
         for (int i = 0; i < message.length(); i++){
@@ -229,9 +235,21 @@ public class ModemCotUtility extends DropDownReceiver implements DropDown.OnStat
            if(callsignToSendTo.equals(myCallsign) || callsignToSendTo.equals("ALL")) {
                android.util.Log.d(TAG, "parseCoT: was equal" );
                for (ChatMessageListener i : chatMessageListenerSet) {
-                   i.chatReceived(chatMessage, callsign, time, callsignToSendTo);
+                   i.chatReceived(chatMessage, callsign, time, callsignToSendTo, crc32);
+                   if (useReadReceipt) {
+                       sendChatAck(callsignToSendTo, crc32);
+                   }
                }
            }
+       }else if (message.contains("ack@@@")) {
+            Log.d(TAG, "handling chatack");
+            String[] result = message.split("@@@");
+            String checksum = result[1]; // the 'message' field holds the checksum
+            //String callsign = result[2]; // from
+            String callsignToSendTo = result[3]; // to
+            for (ChatMessageListener i: chatMessageListenerSet) {
+                i.markRead(callsignToSendTo, checksum);
+            }
         }else {
 
             CotEvent cotEvent = null;
@@ -320,7 +338,25 @@ public class ModemCotUtility extends DropDownReceiver implements DropDown.OnStat
         String callsign = MapView.getMapView().getDeviceCallsign();
         String encodedMessage =  "chat@@@" + message + "@@@" + callsign + "@@@" + callsignToSendTo + "@@@" + System.currentTimeMillis();
 
+        // grab a crc of our outgoing message
+        byte[] msg = new byte[padding.length() + encodedMessage.length()];
+        ByteBuffer bb = ByteBuffer.wrap(msg);
+        bb.put(padding.getBytes());
+        bb.put(encodedMessage.getBytes());
+        CRC32 crc = new CRC32();
+        crc.update(bb.array());
+        MessageCRC = (int) crc.getValue();
+
         android.util.Log.d(TAG, "sending chat message: " + encodedMessage);
+        Sender modemSender = new Sender(this);
+        modemSender.execute(padding + encodedMessage);
+    }
+
+    public void sendChatAck(String callsignToSendTo, int crc32){
+        String myCallsign = MapView.getMapView().getDeviceCallsign();
+        String encodedMessage =  String.format("ack@@@%d@@@%s@@@%s@@@%d",crc32,myCallsign,callsignToSendTo,System.currentTimeMillis());
+
+        android.util.Log.d(TAG, "sending chatack message: " + encodedMessage);
         Sender modemSender = new Sender(this);
         modemSender.execute(padding + encodedMessage);
     }

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -48,4 +48,13 @@
         android:layout_height="50dp"
         android:checked="true"/>
 
+    <Switch
+        android:layout_marginLeft="10dp"
+        android:layout_marginRight="10dp"
+        android:text="Read Receipt"
+        android:id="@+id/readReceipt"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:checked="false"/>
+
 </LinearLayout>


### PR DESCRIPTION
This commit introduces read receipts for chat messages. This is accomplished by sending an
acknowledgment message that contains the crc32 of the recieved message.

Chat messages now contain a "[read]" or "[unread<crc32>]" next to their timestamp.
Upon sending a chat message the line below the message will display the unread status.
After a message is read, if read receipt is enabled, the client will send an ack message
that when parsed by the original sender will update the display to say the read status.