### PR TITLE
PSK mode

### DIFF
--- a/app/src/main/java/audiomodem/Sender.java
+++ b/app/src/main/java/audiomodem/Sender.java
@@ -1,10 +1,14 @@
 package audiomodem;
 
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.media.AudioFormat;
 import android.media.AudioManager;
 import android.media.AudioTrack;
 import android.os.AsyncTask;
 import android.util.Log;
+
+import com.atakmap.android.cot_utility.plugin.PluginLifecycle;
 
 import utils.ModemCotUtility;
 
@@ -14,6 +18,11 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ShortBuffer;
+
+import java.security.SecureRandom;
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import javax.crypto.spec.IvParameterSpec;
 
 import audiomodem.jmodem.Main;
 import audiomodem.jmodem.OutputSampleStream;
@@ -62,7 +71,27 @@ public class Sender extends AsyncTask<String, Double, Void> {
         final int bufSize = AudioTrack.getMinBufferSize(sampleRate, chanFormat, encoding);
 
         OutputBuffer buf = new OutputBuffer();
-        final byte[] data = params[0].getBytes();
+        byte[] data = new byte[1024*32];
+
+        if (modemCotUtility.usePSK) {
+           Log.i(TAG, "PSK enabled");
+           SharedPreferences sharedPref = PluginLifecycle.activity.getSharedPreferences("hammer-prefs", Context.MODE_PRIVATE);
+           String psk = sharedPref.getString("PSKText", "");
+           Log.i(TAG, "PSKText: " + psk);
+           try {
+               byte[] iv = new byte[16];
+               new SecureRandom().nextBytes(iv);
+               Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+               SecretKeySpec key = new SecretKeySpec(psk.getBytes("UTF-8"), "AES");
+               cipher.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(iv));
+               data = cipher.doFinal(params[0].getBytes("UTF-8"));
+           } catch (Exception e) {
+               Log.d(TAG, "PSK problem: " + e);
+               return null;
+           }
+        } else {
+            data = params[0].getBytes();
+        }
 
         Log.i(TAG, "Sending " + data.length + " bytes");
         Log.i(TAG, "Buffer size: " + bufSize);

--- a/app/src/main/java/com/atakmap/android/cot_utility/receivers/SettingsReceiver.java
+++ b/app/src/main/java/com/atakmap/android/cot_utility/receivers/SettingsReceiver.java
@@ -3,12 +3,15 @@ package com.atakmap.android.cot_utility.receivers;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.Switch;
+import android.widget.TextView;
 
 import com.atakmap.android.cot_utility.plugin.PluginLifecycle;
 import com.atakmap.android.cot_utility.plugin.R;
@@ -30,6 +33,8 @@ public class SettingsReceiver extends DropDownReceiver {
 
     private Switch enableReceiveButton;
     private Switch abbreviateCotSwitch;
+    private Switch sharedSecretSwitch;
+    private TextView sharedSecretTV;
     private ModemCotUtility modemCotUtility;
     private Context context;
 
@@ -46,6 +51,8 @@ public class SettingsReceiver extends DropDownReceiver {
 
         enableReceiveButton = settingsView.findViewById(R.id.enableReceiveCoTFromModem);
         abbreviateCotSwitch = settingsView.findViewById(R.id.abbreviateCot);
+        sharedSecretSwitch = settingsView.findViewById(R.id.sharedSecret);
+        sharedSecretTV = settingsView.findViewById(R.id.sharedSecretText);
 
         ImageButton backButton = settingsView.findViewById(R.id.backButtonSettingsView);
         backButton.setOnClickListener(new View.OnClickListener() {
@@ -81,6 +88,41 @@ public class SettingsReceiver extends DropDownReceiver {
                     FULL_HEIGHT, false);
 
             modemCotUtility = ModemCotUtility.getInstance(mapView, context);
+
+            sharedSecretSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+                    ModemCotUtility.usePSK = b;
+
+                    SharedPreferences sharedPref = PluginLifecycle.activity.getSharedPreferences("hammer-prefs", Context.MODE_PRIVATE);
+                    SharedPreferences.Editor editor = sharedPref.edit();
+                    editor.putBoolean("usePSK", b);
+                    editor.apply();
+                }
+            });
+
+            if(ModemCotUtility.usePSK){
+                sharedSecretSwitch.setChecked(true);
+            }else{
+                sharedSecretSwitch.setChecked(false);
+            }
+
+            sharedSecretTV.addTextChangedListener(new TextWatcher() {
+                @Override
+                public void onTextChanged(CharSequence s, int start, int before, int count) {
+                }
+                @Override
+                public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                }
+                @Override
+                public void afterTextChanged(Editable s) {
+                    Log.d(TAG, String.format("PSK Text: %s", s.toString()));
+                    SharedPreferences sharedPref = PluginLifecycle.activity.getSharedPreferences("hammer-prefs", Context.MODE_PRIVATE);
+                    SharedPreferences.Editor editor = sharedPref.edit();
+                    editor.putString("PSKText", s.toString());
+                    editor.apply();
+                }
+            });
 
             abbreviateCotSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                 @Override

--- a/app/src/main/java/utils/ModemCotUtility.java
+++ b/app/src/main/java/utils/ModemCotUtility.java
@@ -46,6 +46,8 @@ public class ModemCotUtility extends DropDownReceiver implements DropDown.OnStat
     private final String padding = "000000000000000000000000000000000000000000000000000000000000000";
     public static boolean useAbbreviatedCoT = true;
 
+    public static boolean usePSK = false;
+
     private Set<ChatMessageListener> chatMessageListenerSet = new HashSet<>();
 
     public interface ChatMessageListener{
@@ -150,7 +152,7 @@ public class ModemCotUtility extends DropDownReceiver implements DropDown.OnStat
         android.util.Log.d(TAG, "startCotListener");
         receiveCot = new AtomicBoolean(false);
 
-        rx = new Receiver(receiveCot) {
+        rx = new Receiver(receiveCot, this) {
             @Override
             protected void onPostExecute(Result res) {
                 android.util.Log.d(TAG, "onPostExecute: " + res.out);

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -48,4 +48,28 @@
         android:layout_height="50dp"
         android:checked="true"/>
 
+    <Switch
+        android:layout_marginLeft="10dp"
+        android:layout_marginRight="10dp"
+        android:text="Use PSK"
+        android:id="@+id/sharedSecret"
+        android:layout_width="match_parent"
+        android:layout_height="50dp"
+        android:checked="true"/>
+
+    <EditText
+        android:id="@+id/sharedSecretText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:layout_marginLeft="10dp"
+        android:layout_marginTop="10dp"
+        android:ems="10"
+        android:hint="Enter PSK here, must be 16,32,64 characters"
+	android:textColor="#000000"
+        android:background="@color/white"
+        android:inputType="textPersonName" />
+    <requestFocus/>
+
+
 </LinearLayout>

--- a/app/src/main/res/layout/settings.xml
+++ b/app/src/main/res/layout/settings.xml
@@ -65,7 +65,7 @@
         android:layout_marginLeft="10dp"
         android:layout_marginTop="10dp"
         android:ems="10"
-        android:hint="Enter PSK here, must be 16,32,64 characters"
+        android:hint="Enter PSK here"
 	android:textColor="#000000"
         android:background="@color/white"
         android:inputType="textPersonName" />


### PR DESCRIPTION
This commit enables encryption for HAMMER messages. 

We accomplish this by taking a user supplied password, hashing it with SHA256, and generating AES/CBC ciphertext of the original message and sending that out instead. Any recipient would need to have the corresponding user password to decrypt.

The previous commit required the user to supply a 16/32/64 character password to generate the appropriate key but now any length password from the user will be accepted since we use the hash now.